### PR TITLE
Expose HTTP client to caller

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -30,7 +30,7 @@ func (c *Crowd) Authenticate(user string, pass string) (User, error) {
 	v.Set("username", user)
 	url := c.url + "rest/usermanagement/1/authentication?" + v.Encode()
 
-	client := http.Client{Jar: c.cookies}
+	c.Client.Jar = c.cookies
 	req, err := http.NewRequest("POST", url, arBuf)
 	if err != nil {
 		return u, err
@@ -38,7 +38,7 @@ func (c *Crowd) Authenticate(user string, pass string) (User, error) {
 	req.SetBasicAuth(c.user, c.passwd)
 	req.Header.Set("Accept", "application/xml")
 	req.Header.Set("Content-Type", "application/xml")
-	resp, err := client.Do(req)
+	resp, err := c.Client.Do(req)
 	if err != nil {
 		return u, err
 	}

--- a/base.go
+++ b/base.go
@@ -14,11 +14,13 @@ type Crowd struct {
 	passwd  string
 	url     string
 	cookies http.CookieJar
+	Client *http.Client
 }
 
 // New initializes & returns a Crowd object.
 func New(appuser string, apppass string, baseurl string) (Crowd, error) {
 	cr := Crowd{
+		Client: http.DefaultClient,
 		user:   appuser,
 		passwd: apppass,
 		url:    baseurl,

--- a/cookie.go
+++ b/cookie.go
@@ -19,7 +19,7 @@ type CookieConfig struct {
 func (c *Crowd) GetCookieConfig() (CookieConfig, error) {
 	cc := CookieConfig{}
 
-	client := http.Client{Jar: c.cookies}
+	c.Client.Jar = c.cookies
 	req, err := http.NewRequest("GET", c.url+"rest/usermanagement/1/config/cookie", nil)
 	if err != nil {
 		return cc, err
@@ -27,7 +27,7 @@ func (c *Crowd) GetCookieConfig() (CookieConfig, error) {
 	req.SetBasicAuth(c.user, c.passwd)
 	req.Header.Set("Accept", "application/xml")
 	req.Header.Set("Content-Type", "application/xml")
-	resp, err := client.Do(req)
+	resp, err := c.Client.Do(req)
 	if err != nil {
 		return cc, err
 	}

--- a/groups.go
+++ b/groups.go
@@ -41,14 +41,14 @@ func (c *Crowd) GetGroups(user string, donested bool) ([]*Group, error) {
 	}
 
 	url := c.url + "rest/usermanagement/1/user/group/" + endpoint + "?" + v.Encode()
-	client := http.Client{Jar: c.cookies}
+	c.Client.Jar = c.cookies
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return groupList.Groups, err
 	}
 	req.SetBasicAuth(c.user, c.passwd)
 	req.Header.Set("Accept", "application/json")
-	resp, err := client.Do(req)
+	resp, err := c.Client.Do(req)
 	if err != nil {
 		return groupList.Groups, err
 	}

--- a/sso.go
+++ b/sso.go
@@ -56,7 +56,7 @@ func (c *Crowd) NewSession(user string, pass string, address string) (Session, e
 
 	url := c.url + "rest/usermanagement/1/session"
 
-	client := http.Client{Jar: c.cookies}
+	c.Client.Jar = c.cookies
 	req, err := http.NewRequest("POST", url, sarBuf)
 	if err != nil {
 		return s, err
@@ -64,7 +64,7 @@ func (c *Crowd) NewSession(user string, pass string, address string) (Session, e
 	req.SetBasicAuth(c.user, c.passwd)
 	req.Header.Set("Accept", "application/xml")
 	req.Header.Set("Content-Type", "application/xml")
-	resp, err := client.Do(req)
+	resp, err := c.Client.Do(req)
 	if err != nil {
 		return s, err
 	}
@@ -112,7 +112,7 @@ func (c *Crowd) ValidateSession(token string, clientaddr string) (Session, error
 
 	url := c.url + "rest/usermanagement/1/session/" + token
 
-	client := http.Client{Jar: c.cookies}
+	c.Client.Jar = c.cookies
 	req, err := http.NewRequest("POST", url, svvfBuf)
 	if err != nil {
 		return s, err
@@ -120,7 +120,7 @@ func (c *Crowd) ValidateSession(token string, clientaddr string) (Session, error
 	req.SetBasicAuth(c.user, c.passwd)
 	req.Header.Set("Accept", "application/xml")
 	req.Header.Set("Content-Type", "application/xml")
-	resp, err := client.Do(req)
+	resp, err := c.Client.Do(req)
 	if err != nil {
 		return s, err
 	}
@@ -161,7 +161,7 @@ func (c *Crowd) ValidateSession(token string, clientaddr string) (Session, error
 
 // Invalidate SSO session token. Returns error on failure.
 func (c *Crowd) InvalidateSession(token string) error {
-	client := http.Client{Jar: c.cookies}
+	c.Client.Jar = c.cookies
 	req, err := http.NewRequest("DELETE", c.url+"rest/usermanagement/1/session/"+token, nil)
 	if err != nil {
 		return err
@@ -169,7 +169,7 @@ func (c *Crowd) InvalidateSession(token string) error {
 	req.SetBasicAuth(c.user, c.passwd)
 	req.Header.Set("Accept", "application/xml")
 	req.Header.Set("Content-Type", "application/xml")
-	resp, err := client.Do(req)
+	resp, err := c.Client.Do(req)
 	if err != nil {
 		return err
 	}
@@ -183,7 +183,7 @@ func (c *Crowd) InvalidateSession(token string) error {
 
 // Get SSO session information by token
 func (c *Crowd) GetSession(token string) (s Session, err error) {
-	client := http.Client{Jar: c.cookies}
+	c.Client.Jar = c.cookies
 	url := c.url + "rest/usermanagement/1/session/" + token
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -192,7 +192,7 @@ func (c *Crowd) GetSession(token string) (s Session, err error) {
 	req.SetBasicAuth(c.user, c.passwd)
 	req.Header.Set("Accept", "application/xml")
 	req.Header.Set("Content-Type", "application/xml")
-	resp, err := client.Do(req)
+	resp, err := c.Client.Do(req)
 	if err != nil {
 		return s, err
 	}

--- a/user.go
+++ b/user.go
@@ -27,7 +27,7 @@ func (c *Crowd) GetUser(user string) (User, error) {
 	v := url.Values{}
 	v.Set("username", user)
 	url := c.url + "rest/usermanagement/1/user?" + v.Encode()
-	client := http.Client{Jar: c.cookies}
+	c.Client.Jar = c.cookies
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return u, err
@@ -35,7 +35,7 @@ func (c *Crowd) GetUser(user string) (User, error) {
 	req.SetBasicAuth(c.user, c.passwd)
 	req.Header.Set("Accept", "application/xml")
 	req.Header.Set("Content-Type", "application/xml")
-	resp, err := client.Do(req)
+	resp, err := c.Client.Do(req)
 	if err != nil {
 		return u, err
 	}


### PR DESCRIPTION
Expose the HTTP client to the caller, so they can configure it if
needed - for example being able to override the clients Transport to use
a proxy.

(Ideally this would be an option you can pass in to New(), but exposing
the client doesn't break the current calling convention)

Example usage for proxying through a local SOCKS5 proxy:

```
package main

import (
	"log"
	"net/http"

	"github.com/jda/go-crowd"
	"golang.org/x/net/proxy"
)

func main() {
	client, err := crowd.New("app_user",
		"app_pass",
		"base_url")

	dialer, err := proxy.SOCKS5("tcp", "localhost:5555", nil, proxy.Direct)
	if err != nil {
		log.Fatal(err)
	}
	transport := &http.Transport{
		Dial: dialer.Dial,
	}
	client.Client.Transport = transport
	user, err := client.Authenticate("username", "password")

	if err != nil {
		log.Fatal(err)
	}
	log.Printf("%+v", user)
}
```